### PR TITLE
Extension error handling

### DIFF
--- a/backend/src/controllers/vidProcess.js
+++ b/backend/src/controllers/vidProcess.js
@@ -17,7 +17,10 @@ router.post("/get_songs", (req, res) => {
 			console.log(songInfo);
 			res.json(songInfo);
 		})
-		.catch((error) => console.log(error));
+		.catch( error => {
+			console.log(error);
+			res.json(error);
+		});
 });
 
 module.exports = router;

--- a/frontend/js/background.js
+++ b/frontend/js/background.js
@@ -1,6 +1,20 @@
 // Listen for song & artist being added to Spotify. Store data in localstorage 
 // for later use
 chrome.runtime.onMessage.addListener( (req, sender, sendResponse) => {
+  if (req.error) {
+    chrome.storage.sync.remove(['addedSongTitle', 'addedSongArtist', 'songAddedTime' ], () => {
+      chrome.storage.sync.set({ error: 'Song not found' })
+      chrome.notifications.create('Song not found', {
+        type: 'basic',
+        iconUrl: '../images/icon32.png',
+        title: 'Song not found',
+        message: `Unfortunately, the song could not be found so nothing was added to your liked songs list on Spotify.`
+      }, () => {
+        console.log('song not found notification sent!')
+      })
+    });
+  };
+
   if (req.title) {
     chrome.storage.sync.set({
       addedSongTitle: req.title,

--- a/frontend/js/popup.js
+++ b/frontend/js/popup.js
@@ -13,8 +13,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 		let songAdded = document.createElement('p');
 		songAdded.innerHTML = `${newSong.addedSongTitle} by ${newSongArtist.addedSongArtist} was added to your liked songs on Spotify ${timePassed} minutes ago!`
 		document.getElementById('song-added').appendChild(songAdded);
-	}
-	
+	} else {
+		let songNotFound = document.createElement('p');
+		songNotFound.innerHTML = 'The last song you attempted to add to Spotify was not found.'
+		document.getElementById('song-added').append(songNotFound);
+	};
 
 	chrome.storage.sync.get('refreshToken', data => {
 		// If refresh token already exists, remove Spotify login button from extension

--- a/frontend/js/ytButton.js
+++ b/frontend/js/ytButton.js
@@ -57,7 +57,7 @@ async function getMusic() {
 	const accessToken = await getLocalValue("accessToken");
 	const data = { videoUrl: document.URL, accessToken: accessToken.accessToken };
 
-	fetch(`https://y2s.main.benchan.tech/api/vidProcess/get_songs`, {
+	fetch(`http://localhost:3000/api/vidProcess/get_songs`, {
 		method: "POST",
 		mode: "cors",
 		headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Add an error message if song cannot be found. This is done by doing the following:

- If an error message is received, remove all previously stored found songs stored in local storage
- Add a key called 'error' to the local storage
- When the chrome extension popup is loaded, it will check for the existence of previously found songs. If it cannot find any entries, this means there was an error finding the song, so an error message saying song not found will be displayed on the popup.
- If a valid song is found later, they will be added back to the local storage. The popup will find the newly added songs and display those songs rather than an error message.